### PR TITLE
Animating to specific index, Swipe enable

### DIFF
--- a/KYAnimatedPageControl-Demo/Classes/KYAnimatedPageControl.h
+++ b/KYAnimatedPageControl-Demo/Classes/KYAnimatedPageControl.h
@@ -57,4 +57,7 @@ typedef enum : NSUInteger {
 //设置完所有参数后，启动这个方法 
 -(void)display;
 
+// Animate to index
+-(void)animateToIndex:(NSInteger)index;
+
 @end

--- a/KYAnimatedPageControl-Demo/Classes/KYAnimatedPageControl.h
+++ b/KYAnimatedPageControl-Demo/Classes/KYAnimatedPageControl.h
@@ -38,6 +38,9 @@ typedef enum : NSUInteger {
 //绑定的滚动视图
 @property(nonatomic,strong)UIScrollView *bindScrollView;
 
+//Possible to swipe (Pan gesture recognize)
+@property(nonatomic,assign)BOOL swipeEnable;
+
 //Indicator样式
 @property(nonatomic,assign)IndicatorStyle indicatorStyle;
 

--- a/KYAnimatedPageControl-Demo/Classes/KYAnimatedPageControl.m
+++ b/KYAnimatedPageControl-Demo/Classes/KYAnimatedPageControl.m
@@ -130,7 +130,23 @@
     
 }
 
-
+-(void)animateToIndex:(NSInteger)index
+{
+    NSAssert(self.bindScrollView != nil, @"You can not scroll without assigning bindScrollView");
+    CGFloat HOWMANYDISTANCE =  ABS((self.line.selectedLineLength - index *((self.line.frame.size.width - self.line.ballDiameter) / (self.line.pageCount - 1)))) / ((self.line.frame.size.width - self.line.ballDiameter) / (self.line.pageCount - 1));
+    NSLog(@"howmanydistance:%f",HOWMANYDISTANCE/self.pageCount);
+    
+    //背景线条动画
+    [self.line animateSelectedLineToNewIndex:index+1];
+    
+    //scrollview 滑动
+    [self.bindScrollView setContentOffset:CGPointMake(self.bindScrollView.frame.size.width *index, 0) animated:YES];
+    
+    //恢复动画
+    [self.indicator performSelector:@selector(restoreAnimation:) withObject:@(HOWMANYDISTANCE/self.pageCount) afterDelay:0.2];
+    
+    NSLog(@"DidSelected index:%ld",(long)index+1);
+}
 
 
 

--- a/KYAnimatedPageControl-Demo/Classes/KYAnimatedPageControl.m
+++ b/KYAnimatedPageControl-Demo/Classes/KYAnimatedPageControl.m
@@ -19,6 +19,7 @@
 @property(nonatomic,strong)GooeyCircle *gooeyCircle;
 @property(nonatomic,strong)RotateRect  *rotateRect;
 
+@property (nonatomic) NSInteger lastIndex;
 
 @end
 
@@ -30,6 +31,8 @@
         
         UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc]initWithTarget:self action:@selector(tapAction:)];
         [self addGestureRecognizer:tap];
+        UIPanGestureRecognizer *pan = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(panAction:)];
+        [self addGestureRecognizer:pan];
 
     }
     return self;
@@ -148,6 +151,24 @@
     NSLog(@"DidSelected index:%ld",(long)index+1);
 }
 
-
+- (void)panAction:(UIPanGestureRecognizer *)pan {
+    if (!_swipeEnable) {
+        return;
+    }
+    
+    CGPoint location = [pan locationInView:self];
+    if (CGRectContainsPoint(self.line.frame, location)) {
+        CGFloat ballDistance = self.frame.size.width / (self.pageCount - 1);
+        NSInteger index =  location.x / ballDistance;
+        if ((location.x - index*ballDistance) >= ballDistance/2) {
+            index += 1;
+        }
+        
+        if (index != _lastIndex) {
+            [self animateToIndex:index];
+            _lastIndex = index;
+        }
+    }
+}
 
 @end

--- a/KYAnimatedPageControl-Demo/KYAnimatedPageControl-Demo/Base.lproj/Main.storyboard
+++ b/KYAnimatedPageControl-Demo/KYAnimatedPageControl-Demo/Base.lproj/Main.storyboard
@@ -79,12 +79,32 @@
                                     <action selector="animateToForthPage:" destination="BYZ-38-t0r" eventType="touchUpInside" id="AeS-0n-Q9C"/>
                                 </connections>
                             </button>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Swipe enable" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="e1b-3k-TMI">
+                                <rect key="frame" x="16" y="571" width="104" height="21"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="21" id="IxI-aG-ulo"/>
+                                    <constraint firstAttribute="width" constant="104" id="ix6-Pl-CsQ"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="OV4-YL-pk2">
+                                <rect key="frame" x="128" y="566" width="51" height="31"/>
+                                <connections>
+                                    <action selector="swipeEnableChanged:" destination="BYZ-38-t0r" eventType="valueChanged" id="hAA-JU-KvE"/>
+                                </connections>
+                            </switch>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstItem="wfy-db-euE" firstAttribute="top" secondItem="Ele-OK-NhY" secondAttribute="bottom" constant="8" id="2sF-bn-F9N"/>
                             <constraint firstAttribute="centerX" secondItem="XhU-ad-KPF" secondAttribute="centerX" id="KPh-jB-TTf"/>
+                            <constraint firstItem="wfy-db-euE" firstAttribute="top" secondItem="OV4-YL-pk2" secondAttribute="bottom" constant="3" id="QjJ-Bi-zq9"/>
+                            <constraint firstItem="OV4-YL-pk2" firstAttribute="leading" secondItem="e1b-3k-TMI" secondAttribute="trailing" constant="8" id="XM9-KL-xNX"/>
+                            <constraint firstItem="wfy-db-euE" firstAttribute="top" secondItem="e1b-3k-TMI" secondAttribute="bottom" constant="8" id="Yfy-0N-TpF"/>
                             <constraint firstItem="XhU-ad-KPF" firstAttribute="top" secondItem="y3c-jy-aDJ" secondAttribute="bottom" constant="10" id="b0M-UD-wsf"/>
+                            <constraint firstItem="e1b-3k-TMI" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leading" constant="16" id="kJi-aj-GlS"/>
                             <constraint firstAttribute="trailing" secondItem="Ele-OK-NhY" secondAttribute="trailing" constant="16" id="ljc-2i-ftC"/>
                         </constraints>
                     </view>

--- a/KYAnimatedPageControl-Demo/KYAnimatedPageControl-Demo/Base.lproj/Main.storyboard
+++ b/KYAnimatedPageControl-Demo/KYAnimatedPageControl-Demo/Base.lproj/Main.storyboard
@@ -66,11 +66,26 @@
                                     <outlet property="delegate" destination="BYZ-38-t0r" id="DaH-oL-Vf7"/>
                                 </connections>
                             </collectionView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ele-OK-NhY">
+                                <rect key="frame" x="423" y="562" width="161" height="30"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="161" id="5Fp-kE-4Vl"/>
+                                    <constraint firstAttribute="height" constant="30" id="BQD-rf-F0X"/>
+                                </constraints>
+                                <state key="normal" title="Animate to Page 4">
+                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <connections>
+                                    <action selector="animateToForthPage:" destination="BYZ-38-t0r" eventType="touchUpInside" id="AeS-0n-Q9C"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                         <constraints>
+                            <constraint firstItem="wfy-db-euE" firstAttribute="top" secondItem="Ele-OK-NhY" secondAttribute="bottom" constant="8" id="2sF-bn-F9N"/>
                             <constraint firstAttribute="centerX" secondItem="XhU-ad-KPF" secondAttribute="centerX" id="KPh-jB-TTf"/>
                             <constraint firstItem="XhU-ad-KPF" firstAttribute="top" secondItem="y3c-jy-aDJ" secondAttribute="bottom" constant="10" id="b0M-UD-wsf"/>
+                            <constraint firstAttribute="trailing" secondItem="Ele-OK-NhY" secondAttribute="trailing" constant="16" id="ljc-2i-ftC"/>
                         </constraints>
                     </view>
                     <connections>

--- a/KYAnimatedPageControl-Demo/KYAnimatedPageControl-Demo/ViewController.h
+++ b/KYAnimatedPageControl-Demo/KYAnimatedPageControl-Demo/ViewController.h
@@ -11,6 +11,7 @@
 @interface ViewController : UIViewController
 
 - (IBAction)animateToForthPage:(id)sender;
+- (IBAction)swipeEnableChanged:(UISwitch *)sender;
 
 @end
 

--- a/KYAnimatedPageControl-Demo/KYAnimatedPageControl-Demo/ViewController.h
+++ b/KYAnimatedPageControl-Demo/KYAnimatedPageControl-Demo/ViewController.h
@@ -10,6 +10,7 @@
 
 @interface ViewController : UIViewController
 
+- (IBAction)animateToForthPage:(id)sender;
 
 @end
 

--- a/KYAnimatedPageControl-Demo/KYAnimatedPageControl-Demo/ViewController.m
+++ b/KYAnimatedPageControl-Demo/KYAnimatedPageControl-Demo/ViewController.m
@@ -31,6 +31,7 @@
     
     self.pageControl.indicatorStyle = IndicatorStyleGooeyCircle;
     self.pageControl.indicatorSize = 20;
+    self.pageControl.swipeEnable = YES;
     [self.pageControl display];
     [self.view addSubview:self.pageControl];
     
@@ -98,7 +99,10 @@
     [self.pageControl animateToIndex:3];
 }
 
-
+- (IBAction)swipeEnableChanged:(UISwitch *)sender
+{
+    self.pageControl.swipeEnable = sender.isOn;
+}
 
 
 

--- a/KYAnimatedPageControl-Demo/KYAnimatedPageControl-Demo/ViewController.m
+++ b/KYAnimatedPageControl-Demo/KYAnimatedPageControl-Demo/ViewController.m
@@ -91,6 +91,12 @@
     // Dispose of any resources that can be recreated.
 }
 
+#pragma mark - Action
+
+- (IBAction)animateToForthPage:(id)sender
+{
+    [self.pageControl animateToIndex:3];
+}
 
 
 


### PR DESCRIPTION
## Animating to specific index.
- `KYAnimatedPageControl` is really great library. But I saw that there is **no way to animate to specific index** in the KYAnimatedPageControl.
- I add method `animateToIndex:` to `KYAnimatedPageControl` class.
  - This method will animate page control to specific index.

---
## Swipe to change index.
- I saw that `KYAnimatedPageControl` doesn't support swipe _(UIPanGestureRecognizer)_.
- I added `swipeEnable` property to `KYAnimatedPageControl` class.
  - Add pan gesture recognizer into `KYAnimatedPageControl` to detect pan gesture.
  - If  `swipeEnable` value is YES, animate to the index with the pan gesture.

---
### _Why Not Demo?_
- I also write some code to demonstrate new feature (`animateToIndex:`, `swipeEnable`).
  - `ViewController` , `Main Storyboard`
