### PR TITLE
scroll view delegate improvement

### DIFF
--- a/KYAnimatedPageControl-Demo/Classes/KYAnimatedPageControl.h
+++ b/KYAnimatedPageControl-Demo/Classes/KYAnimatedPageControl.h
@@ -37,6 +37,8 @@ typedef enum : NSUInteger {
 
 //绑定的滚动视图
 @property(nonatomic,strong)UIScrollView *bindScrollView;
+//default delegate for bind scrollview
+@property(nonatomic, weak, readonly) id<UIScrollViewDelegate> bindScrollViewDelegate;
 
 //Possible to swipe (Pan gesture recognize)
 @property(nonatomic,assign)BOOL swipeEnable;

--- a/KYAnimatedPageControl-Demo/Classes/KYAnimatedPageControl.h
+++ b/KYAnimatedPageControl-Demo/Classes/KYAnimatedPageControl.h
@@ -58,7 +58,7 @@ typedef enum : NSUInteger {
 @property(nonatomic,readonly)Line *pageControlLine;
 
 // Animate to index
--(void)animateToIndex:(NSInteger)index;
+-(void)animateToIndex:(NSUInteger)index;
 
 //选中某个index的回调 DidSelecteSomeIndex Block
 @property(nonatomic,copy)void(^didSelectIndexBlock)(NSInteger index);

--- a/KYAnimatedPageControl-Demo/Classes/KYAnimatedPageControl.m
+++ b/KYAnimatedPageControl-Demo/Classes/KYAnimatedPageControl.m
@@ -20,6 +20,8 @@
 @property(nonatomic,strong)GooeyCircle *gooeyCircle;
 @property(nonatomic,strong)RotateRect  *rotateRect;
 
+@property(nonatomic, weak) id<UIScrollViewDelegate> scrollViewDelegate;
+
 
 @property (nonatomic) NSInteger lastIndex;
 
@@ -37,6 +39,9 @@
         [self addGestureRecognizer:pan];
         
         self.layer.masksToBounds = NO;
+        
+        //init scrollviewDelegate
+        self.scrollViewDelegate = self;
     }
     return self;
 }
@@ -128,7 +133,7 @@
 - (void)setBindScrollView:(UIScrollView *)bindScrollView
 {
     _bindScrollView = bindScrollView;
-    _bindScrollView.delegate = self;
+    _bindScrollView.delegate = self.scrollViewDelegate;
 }
 
 #pragma mark -- UITapGestureRecognizer tapAction

--- a/KYAnimatedPageControl-Demo/Classes/KYAnimatedPageControl.m
+++ b/KYAnimatedPageControl-Demo/Classes/KYAnimatedPageControl.m
@@ -114,6 +114,16 @@
     return self.line;
 }
 
+- (NSInteger)selectedPage
+{
+    return self.line.selectedPage;
+}
+
+- (void)setSelectedPage:(NSInteger)selectedPage
+{
+    self.line.selectedPage = selectedPage;
+}
+
 #pragma mark -- UITapGestureRecognizer tapAction
 -(void)tapAction:(UITapGestureRecognizer *)ges{
     

--- a/KYAnimatedPageControl-Demo/Classes/KYAnimatedPageControl.m
+++ b/KYAnimatedPageControl-Demo/Classes/KYAnimatedPageControl.m
@@ -20,8 +20,6 @@
 @property(nonatomic,strong)GooeyCircle *gooeyCircle;
 @property(nonatomic,strong)RotateRect  *rotateRect;
 
-@property(nonatomic, weak) id<UIScrollViewDelegate> scrollViewDelegate;
-
 
 @property (nonatomic) NSInteger lastIndex;
 
@@ -41,7 +39,7 @@
         self.layer.masksToBounds = NO;
         
         //init scrollviewDelegate
-        self.scrollViewDelegate = self;
+        _bindScrollViewDelegate = self;
     }
     return self;
 }
@@ -133,7 +131,6 @@
 - (void)setBindScrollView:(UIScrollView *)bindScrollView
 {
     _bindScrollView = bindScrollView;
-    _bindScrollView.delegate = self.scrollViewDelegate;
 }
 
 #pragma mark -- UITapGestureRecognizer tapAction

--- a/KYAnimatedPageControl-Demo/Classes/KYAnimatedPageControl.m
+++ b/KYAnimatedPageControl-Demo/Classes/KYAnimatedPageControl.m
@@ -8,6 +8,7 @@
 
 
 #import "KYAnimatedPageControl.h"
+#import "KYAnimatedPageControl+UIScrollViewDelegate.h"
 #import "GooeyCircle.h"
 #import "RotateRect.h"
 
@@ -122,6 +123,12 @@
 - (void)setSelectedPage:(NSInteger)selectedPage
 {
     self.line.selectedPage = selectedPage;
+}
+
+- (void)setBindScrollView:(UIScrollView *)bindScrollView
+{
+    _bindScrollView = bindScrollView;
+    _bindScrollView.delegate = self;
 }
 
 #pragma mark -- UITapGestureRecognizer tapAction

--- a/KYAnimatedPageControl-Demo/Classes/KYAnimatedPageControl.m
+++ b/KYAnimatedPageControl-Demo/Classes/KYAnimatedPageControl.m
@@ -163,9 +163,15 @@
     
 }
 
--(void)animateToIndex:(NSInteger)index
+-(void)animateToIndex:(NSUInteger)index
 {
     NSAssert(self.bindScrollView != nil, @"You can not scroll without assigning bindScrollView");
+    
+    if(index >= self.pageCount)
+    {
+        return;
+    }
+    
     CGFloat HOWMANYDISTANCE =  ABS((self.line.selectedLineLength - index *((self.line.frame.size.width - self.line.ballDiameter) / (self.line.pageCount - 1)))) / ((self.line.frame.size.width - self.line.ballDiameter) / (self.line.pageCount - 1));
     NSLog(@"howmanydistance:%f",HOWMANYDISTANCE/self.pageCount);
     

--- a/KYAnimatedPageControl-Demo/Classes/Line.m
+++ b/KYAnimatedPageControl-Demo/Classes/Line.m
@@ -196,6 +196,8 @@
     CGFloat offSetX = scrollView.contentOffset.x - lastContentOffsetX;
     
     self.selectedLineLength = initialSelectedLineLength + (offSetX/scrollView.frame.size.width) * DISTANCE;
+    _selectedPage = self.selectedLineLength/DISTANCE + 1;//update the selectedPage while scrolling
+    
     [self setNeedsDisplay];
 
 }

--- a/KYAnimatedPageControl-Demo/KYAnimatedPageControl-Demo.xcodeproj/project.pbxproj
+++ b/KYAnimatedPageControl-Demo/KYAnimatedPageControl-Demo.xcodeproj/project.pbxproj
@@ -109,13 +109,13 @@
 				5F49CE5E1B26C3BB00C304FE /* AppDelegate.m */,
 				5F793B3C1B29965600A77B17 /* DemoCell.h */,
 				5F793B3D1B29965700A77B17 /* DemoCell.m */,
+				5F49CE661B26C3BB00C304FE /* Images.xcassets */,
+				5F793B2D1B286F5900A77B17 /* KYAnimatedPageControl */,
+				5F49CE681B26C3BB00C304FE /* LaunchScreen.xib */,
+				5F49CE631B26C3BB00C304FE /* Main.storyboard */,
+				5F49CE591B26C3BB00C304FE /* Supporting Files */,
 				5F49CE601B26C3BB00C304FE /* ViewController.h */,
 				5F49CE611B26C3BB00C304FE /* ViewController.m */,
-				5F793B2D1B286F5900A77B17 /* KYAnimatedPageControl */,
-				5F49CE631B26C3BB00C304FE /* Main.storyboard */,
-				5F49CE661B26C3BB00C304FE /* Images.xcassets */,
-				5F49CE681B26C3BB00C304FE /* LaunchScreen.xib */,
-				5F49CE591B26C3BB00C304FE /* Supporting Files */,
 			);
 			path = "KYAnimatedPageControl-Demo";
 			sourceTree = "<group>";
@@ -158,12 +158,12 @@
 		5F793B2D1B286F5900A77B17 /* KYAnimatedPageControl */ = {
 			isa = PBXGroup;
 			children = (
+				5F793B341B289FD000A77B17 /* IndicatorStyle */,
 				5F793B2A1B286F5100A77B17 /* KYAnimatedPageControl.h */,
+				5F793B2B1B286F5100A77B17 /* KYAnimatedPageControl.m */,
 				3E39D1F71B6494020018B144 /* KYAnimatedPageControl+UIScrollViewDelegate.h */,
 				3E39D1F81B6494020018B144 /* KYAnimatedPageControl+UIScrollViewDelegate.m */,
-				5F793B2B1B286F5100A77B17 /* KYAnimatedPageControl.m */,
 				5F793B381B28A1BA00A77B17 /* Line */,
-				5F793B341B289FD000A77B17 /* IndicatorStyle */,
 				5F793B291B286F4500A77B17 /* SpringAnimation */,
 			);
 			name = KYAnimatedPageControl;

--- a/KYAnimatedPageControl-Demo/KYAnimatedPageControl-Demo.xcodeproj/project.pbxproj
+++ b/KYAnimatedPageControl-Demo/KYAnimatedPageControl-Demo.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3E39D1F91B6494020018B144 /* KYAnimatedPageControl+UIScrollViewDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 3E39D1F81B6494020018B144 /* KYAnimatedPageControl+UIScrollViewDelegate.m */; };
 		5F49CE5C1B26C3BB00C304FE /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 5F49CE5B1B26C3BB00C304FE /* main.m */; };
 		5F49CE5F1B26C3BB00C304FE /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 5F49CE5E1B26C3BB00C304FE /* AppDelegate.m */; };
 		5F49CE621B26C3BB00C304FE /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5F49CE611B26C3BB00C304FE /* ViewController.m */; };
@@ -34,6 +35,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		3E39D1F71B6494020018B144 /* KYAnimatedPageControl+UIScrollViewDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "KYAnimatedPageControl+UIScrollViewDelegate.h"; sourceTree = "<group>"; };
+		3E39D1F81B6494020018B144 /* KYAnimatedPageControl+UIScrollViewDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "KYAnimatedPageControl+UIScrollViewDelegate.m"; sourceTree = "<group>"; };
 		5F49CE561B26C3BB00C304FE /* KYAnimatedPageControl-Demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "KYAnimatedPageControl-Demo.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		5F49CE5A1B26C3BB00C304FE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		5F49CE5B1B26C3BB00C304FE /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
@@ -156,6 +159,8 @@
 			isa = PBXGroup;
 			children = (
 				5F793B2A1B286F5100A77B17 /* KYAnimatedPageControl.h */,
+				3E39D1F71B6494020018B144 /* KYAnimatedPageControl+UIScrollViewDelegate.h */,
+				3E39D1F81B6494020018B144 /* KYAnimatedPageControl+UIScrollViewDelegate.m */,
 				5F793B2B1B286F5100A77B17 /* KYAnimatedPageControl.m */,
 				5F793B381B28A1BA00A77B17 /* Line */,
 				5F793B341B289FD000A77B17 /* IndicatorStyle */,
@@ -320,6 +325,7 @@
 				5F793B461B2A935E00A77B17 /* Indicator.m in Sources */,
 				5F793B251B28345A00A77B17 /* KYSpringLayerAnimation.m in Sources */,
 				5F793B301B289F2500A77B17 /* GooeyCircle.m in Sources */,
+				3E39D1F91B6494020018B144 /* KYAnimatedPageControl+UIScrollViewDelegate.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/KYAnimatedPageControl-Demo/KYAnimatedPageControl-Demo/Base.lproj/Main.storyboard
+++ b/KYAnimatedPageControl-Demo/KYAnimatedPageControl-Demo/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7706" systemVersion="14E36b" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7706" systemVersion="14E46" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
@@ -42,7 +42,7 @@
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9pi-CN-6gm">
                                                     <rect key="frame" x="8" y="8" width="264" height="384"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="100"/>
-                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
@@ -63,7 +63,6 @@
                                 </cells>
                                 <connections>
                                     <outlet property="dataSource" destination="BYZ-38-t0r" id="KVS-DN-u9F"/>
-                                    <outlet property="delegate" destination="BYZ-38-t0r" id="DaH-oL-Vf7"/>
                                 </connections>
                             </collectionView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ele-OK-NhY">
@@ -86,7 +85,7 @@
                                     <constraint firstAttribute="width" constant="104" id="ix6-Pl-CsQ"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="OV4-YL-pk2">

--- a/KYAnimatedPageControl-Demo/KYAnimatedPageControl-Demo/KYAnimatedPageControl+UIScrollViewDelegate.h
+++ b/KYAnimatedPageControl-Demo/KYAnimatedPageControl-Demo/KYAnimatedPageControl+UIScrollViewDelegate.h
@@ -1,0 +1,13 @@
+//
+//  KYAnimatedPageControl+UIScrollViewDelegate.h
+//  KYAnimatedPageControl-Demo
+//
+//  Created by jiakai lian on 26/07/2015.
+//  Copyright (c) 2015 Kitten Yang. All rights reserved.
+//
+
+#import "KYAnimatedPageControl.h"
+
+@interface KYAnimatedPageControl (UIScrollViewDelegate) <UIScrollViewDelegate>
+
+@end

--- a/KYAnimatedPageControl-Demo/KYAnimatedPageControl-Demo/KYAnimatedPageControl+UIScrollViewDelegate.m
+++ b/KYAnimatedPageControl-Demo/KYAnimatedPageControl-Demo/KYAnimatedPageControl+UIScrollViewDelegate.m
@@ -1,0 +1,46 @@
+//
+//  KYAnimatedPageControl+UIScrollViewDelegate.m
+//  KYAnimatedPageControl-Demo
+//
+//  Created by jiakai lian on 26/07/2015.
+//  Copyright (c) 2015 Kitten Yang. All rights reserved.
+//
+
+#import "KYAnimatedPageControl+UIScrollViewDelegate.h"
+
+@implementation KYAnimatedPageControl (UIScrollViewDelegate) 
+
+
+#pragma mark -- UIScrollViewDelegate
+-(void)scrollViewDidScroll:(UIScrollView *)scrollView{
+    
+    //Indicator动画
+    [self.indicator animateIndicatorWithScrollView:scrollView andIndicator:self];
+    
+    if (scrollView.dragging || scrollView.isDecelerating || scrollView.tracking) {
+        //背景线条动画
+        [self.pageControlLine animateSelectedLineWithScrollView:scrollView];
+    }
+    
+}
+
+
+-(void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView{
+    
+    self.indicator.lastContentOffset = scrollView.contentOffset.x;
+    
+}
+
+-(void)scrollViewWillBeginDecelerating:(UIScrollView *)scrollView{
+    
+    [self.indicator restoreAnimation:@(1.0/self.pageCount)];
+    
+}
+
+- (void)scrollViewDidEndScrollingAnimation:(UIScrollView *)scrollView{
+    self.indicator.lastContentOffset = scrollView.contentOffset.x;
+}
+
+
+
+@end

--- a/KYAnimatedPageControl-Demo/KYAnimatedPageControl-Demo/ViewController.m
+++ b/KYAnimatedPageControl-Demo/KYAnimatedPageControl-Demo/ViewController.m
@@ -27,6 +27,7 @@
     self.pageControl.unSelectedColor = [UIColor colorWithWhite:0.9 alpha:1];
     self.pageControl.selectedColor = [UIColor redColor];
     self.pageControl.bindScrollView = self.demoCollectionView;
+    ((UIScrollView *)self.demoCollectionView).delegate = self.pageControl.bindScrollViewDelegate;
     self.pageControl.shouldShowProgressLine = YES;
     
     self.pageControl.indicatorStyle = IndicatorStyleGooeyCircle;

--- a/KYAnimatedPageControl-Demo/KYAnimatedPageControl-Demo/ViewController.m
+++ b/KYAnimatedPageControl-Demo/KYAnimatedPageControl-Demo/ViewController.m
@@ -40,9 +40,6 @@
     
 }
 
-
-
-
 #pragma mark  -- UICollectionViewDataSource
 - (NSInteger)collectionView:(UICollectionView *)collectionView numberOfItemsInSection:(NSInteger)section{
     
@@ -53,47 +50,11 @@
 - (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView cellForItemAtIndexPath:(NSIndexPath *)indexPath{
 
     DemoCell *democell = (DemoCell *)[collectionView dequeueReusableCellWithReuseIdentifier:@"democell" forIndexPath:indexPath];
-    democell.cellNumLabel.text = [NSString stringWithFormat:@"%ld",indexPath.item + 1];
+    democell.cellNumLabel.text = [NSString stringWithFormat:@"%d",indexPath.item + 1];
     
     return democell;
     
 }
-
-
-
-#pragma mark -- UIScrollViewDelegate
--(void)scrollViewDidScroll:(UIScrollView *)scrollView{
-
-    //Indicator动画
-    [self.pageControl.indicator animateIndicatorWithScrollView:scrollView andIndicator:self.pageControl];
-
-    if (scrollView.dragging || scrollView.isDecelerating || scrollView.tracking) {
-        //背景线条动画
-        [self.pageControl.pageControlLine animateSelectedLineWithScrollView:scrollView];
-    }
-    
-}
-
-
--(void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView{
-    
-    
-    self.pageControl.indicator.lastContentOffset = scrollView.contentOffset.x;
-    
-}
-
--(void)scrollViewWillBeginDecelerating:(UIScrollView *)scrollView{
-
-    
-    [self.pageControl.indicator restoreAnimation:@(1.0/self.pageControl.pageCount)];
-
-}
-
-- (void)scrollViewDidEndScrollingAnimation:(UIScrollView *)scrollView{
-    self.pageControl.indicator.lastContentOffset = scrollView.contentOffset.x;
-}
-
-
 
 - (void)didReceiveMemoryWarning {
     [super didReceiveMemoryWarning];


### PR DESCRIPTION
In most scenarios, the scrollview delegates are identical.
So I moved the scrollview delegate into a category, and set it to the bind scroll view in the setBindScrollView method.
When using this control, there is no need to set the scrollview delegate again.
